### PR TITLE
Randomize players colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ returns information on a given alien's powers and flare.
 
 ---
 ```
-!color <player1> <player2> [<playerN> ...]
+!color <player1> <player2> <player3> [<playerN> ...]
 ```
 assigns all players given to a different, randomly choosen color.
 

--- a/README.md
+++ b/README.md
@@ -3,4 +3,17 @@
 Commands supported:
 ```
 !alien <alien name>
+``` 
+returns information on a given alien's powers and flare.
+
+---
 ```
+!color <player1> <player2> [<playerN> ...]
+```
+assigns all players given to a different, randomly choosen color.
+
+---
+```
+!colors
+```
+assigns all players in voice chat to a different, randomly choosen color.

--- a/bot.py
+++ b/bot.py
@@ -37,7 +37,10 @@ async def color(ctx, *args):
 @bot.command()
 async def colors(ctx):
     players = [member.nick if member.nick is not None else member.name for voice_channel in ctx.guild.voice_channels for member in voice_channel.members]
-    await ctx.send(", ".join(map(str, zip(players, random.sample(COLORS, len(players))))))
+    try:
+        await ctx.send(", ".join(map(str, zip(players, random.sample(COLORS, len(players))))))
+    except ValueError:
+        await ctx.send(f"Having {len(players)} players is above the 8 player maximum")
 
 with open('./secret_config.json', 'r') as f:
     data = json.load(f)

--- a/bot.py
+++ b/bot.py
@@ -32,7 +32,7 @@ async def color(ctx, *args):
     if 3 <= len(args) <= 8:
         await ctx.send(", ".join(map(str, zip(args, random.sample(COLORS, len(args))))))
     else:
-        await ctx.send(f"Having {len(args)} players is within the 3-8 player ruleset")
+        await ctx.send(f"Having {len(args)} players is not within the 3-8 player ruleset")
 
 @bot.command()
 async def colors(ctx):
@@ -40,7 +40,7 @@ async def colors(ctx):
     if 3 <= len(players) <= 8:
         await ctx.send(", ".join(map(str, zip(players, random.sample(COLORS, len(players))))))
     else:
-        await ctx.send(f"Having {len(players)} players is within the 3-8 player ruleset")
+        await ctx.send(f"Having {len(players)} players is not within the 3-8 player ruleset")
 
 
 with open('./secret_config.json', 'r') as f:

--- a/bot.py
+++ b/bot.py
@@ -1,9 +1,12 @@
-from discord.ext import commands
 import json
+import random
+
+from discord.ext import commands
 
 aliens = open("alien_scrape.txt", 'r').read().split('\n\n\n')
 
 alien_dict = {}
+colors = ("Pink", "White", "Green", "Yellow", "Purple", "Red", "Blue", "Orange")
 
 for alien in aliens:
     (key, _) = alien.split('[')
@@ -20,6 +23,13 @@ async def alien(ctx, *args):
     else:
         await ctx.send("Could not find alien named {alien_name}".format(
             alien_name=alien_name))
+
+@bot.command()
+async def color(ctx, *args):
+    if len(args) > 8:
+        await ctx.send("Having {len(args)} players is above the 8 player maximum")
+    else:
+        await ctx.send(", ".join(map(str, zip(args, random.sample(colors, len(args))))))
 
 
 with open('./secret_config.json', 'r') as f:

--- a/bot.py
+++ b/bot.py
@@ -27,7 +27,7 @@ async def alien(ctx, *args):
 @bot.command()
 async def color(ctx, *args):
     if len(args) > 8:
-        await ctx.send("Having {len(args)} players is above the 8 player maximum")
+        await ctx.send(f"Having {len(args)} players is above the 8 player maximum")
     else:
         await ctx.send(", ".join(map(str, zip(args, random.sample(colors, len(args))))))
 

--- a/bot.py
+++ b/bot.py
@@ -29,18 +29,19 @@ async def alien(ctx, *args):
 
 @bot.command()
 async def color(ctx, *args):
-    if len(args) > 8:
-        await ctx.send(f"Having {len(args)} players is above the 8 player maximum")
-    else:
+    if 3 <= len(args) <= 8:
         await ctx.send(", ".join(map(str, zip(args, random.sample(COLORS, len(args))))))
+    else:
+        await ctx.send(f"Having {len(args)} players is within the 3-8 player ruleset")
 
 @bot.command()
 async def colors(ctx):
     players = [member.nick if member.nick is not None else member.name for voice_channel in ctx.guild.voice_channels for member in voice_channel.members]
-    try:
+    if 3 <= len(players) <= 8:
         await ctx.send(", ".join(map(str, zip(players, random.sample(COLORS, len(players))))))
-    except ValueError:
-        await ctx.send(f"Having {len(players)} players is above the 8 player maximum")
+    else:
+        await ctx.send(f"Having {len(players)} players is within the 3-8 player ruleset")
+
 
 with open('./secret_config.json', 'r') as f:
     data = json.load(f)

--- a/bot.py
+++ b/bot.py
@@ -1,18 +1,21 @@
 import json
 import random
 
+import discord
 from discord.ext import commands
 
 aliens = open("alien_scrape.txt", 'r').read().split('\n\n\n')
 
 alien_dict = {}
-colors = ("Pink", "White", "Green", "Yellow", "Purple", "Red", "Blue", "Orange")
+COLORS = frozenset(("Pink", "White", "Green", "Yellow", "Purple", "Red", "Blue", "Orange"))
 
 for alien in aliens:
     (key, _) = alien.split('[')
     alien_dict[key.strip().lower()] = alien
 
-bot = commands.Bot(command_prefix='!')
+intents = discord.Intents.default()
+intents.members = True
+bot = commands.Bot(command_prefix='!', intents=intents)
 
 
 @bot.command()
@@ -29,8 +32,12 @@ async def color(ctx, *args):
     if len(args) > 8:
         await ctx.send(f"Having {len(args)} players is above the 8 player maximum")
     else:
-        await ctx.send(", ".join(map(str, zip(args, random.sample(colors, len(args))))))
+        await ctx.send(", ".join(map(str, zip(args, random.sample(COLORS, len(args))))))
 
+@bot.command()
+async def colors(ctx):
+    players = [member.nick if member.nick is not None else member.name for voice_channel in ctx.guild.voice_channels for member in voice_channel.members]
+    await ctx.send(", ".join(map(str, zip(players, random.sample(COLORS, len(players))))))
 
 with open('./secret_config.json', 'r') as f:
     data = json.load(f)


### PR DESCRIPTION
**Example**:
```
!color player1 player2 player3 player4
```
may return
```
('player1', 'Green'), ('player2', 'Red'), ('player3', 'Pink'), ('player4', 'Orange')
```

The second function, `!colors`, simply assigns players in voice chat a color automatically.

**Tested**:
![image](https://user-images.githubusercontent.com/1873994/96360466-66466c80-10d2-11eb-8f91-e977c5862504.png)
![image](https://user-images.githubusercontent.com/1873994/96360500-aefe2580-10d2-11eb-95f9-4f787e46d40b.png)

**FYI**:

`!colors` requires member intents to be turned for the bot in both the the developer portal and script: https://discordpy.readthedocs.io/en/latest/intents.html
